### PR TITLE
Fix HTML 5 validation error

### DIFF
--- a/views/apt.html.erb
+++ b/views/apt.html.erb
@@ -5,11 +5,11 @@
           <h1>APT And Docker</h1>
           <p>
             There are two methods for getting started quickly on a linux machine:
+          </p>
             <ol>
               <li>Add an apt repository to a debian or ubuntu installation.</li>
               <li>Install a docker image on a <a href="https://www.docker.com/">docker</a> supporting system.</li>
             </ol>
-          </p>
           <h2>1. APT Repository</h2>
   	    <p>
   	    We provide an APT repository for Debian and Ubuntu users, for bitcoind and 64 bit machines only. To use it, follow these steps.


### PR DESCRIPTION
All pages of bitcoinxt.software are valid HTML 5 (with some warnings, but no errors) if the </p> is moved. 

Sorry, I was having trouble with my gh account.
