### PR TITLE
Fix active anchors' position on screen

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -15,10 +15,10 @@ h2 {
 }
 
 /* Make scrolling to #anchor elements work with the header */
-div > a:target,
+section > div > h2 > a:target,
 section > div > h2:target {
-  padding-top: 140px;
-  margin-top: -140px;
+  padding-top: 150px;
+  margin-top: -150px;
 }
 
 #download-link.myButton {


### PR DESCRIPTION
When linking to an anchor in the FAQ, the title and part of the subsection is hidden under the menu header. This is due to a previous CSS rule not applying correctly (anymore?) to the HTML structure of the FAQ.

E.g. https://bitcoinxt.software/faq.html#why-did-the-xt-fork-happen
