### PR TITLE
New docker image

### DIFF
--- a/_layouts/index-page.html
+++ b/_layouts/index-page.html
@@ -27,7 +27,7 @@ description: "Bitcoin XT is an implementation of a full node that embraces Bitco
         <div id="download">
             <a id="download-link" href="https://github.com/bitcoinxt/bitcoinxt/releases/latest" class="myButton mg-btm-05" title="Download now"><i class="fa fa-download fa-1x"></i>Download now</a>
             <div id="releases-page-links">
-            <a class="muted_link" href="apt.html" title="APT repository - Bitcoin XT">apt repository</a>
+            <a href="apt.html" title="APT repository">APT Repository</a>&nbsp;&mdash;&nbsp;<a href="apt.html" title="Docker image">Docker Image</a>
             </div>
         </div>
 

--- a/apt.html
+++ b/apt.html
@@ -13,7 +13,7 @@ description: "We provide an APT repository for Debian and Ubuntu users, for bitc
           </p>
             <ol>
               <li>Add an apt repository to a debian or ubuntu installation.</li>
-              <li>Install a docker image on a <a href="https://www.docker.com/" title="Docker - Build, Ship, and Run Any App, Anywhere">docker</a> supporting system.</li>
+              <li>Install a docker image on a <a href="https://www.docker.com/" title="Docker">docker</a> supporting system.</li>
             </ol>
           <p></p>
           <h2>1. APT Repository</h2>
@@ -79,8 +79,8 @@ EOF</code></pre>
         <h2>2. Docker Image</h2>
 
         <p>
-        There is a third party docker image created by 5an1ty hosted on dockerhub:
-        <a href="https://hub.docker.com/r/5an1ty/bitcoinxt/" title="Bitcoin XT on Docker Hub">5an1ty/bitcoinxt</a>
+        There is a docker image hosted on dockerhub:
+        <a href="https://hub.docker.com/r/bitcoinxt/bitcoinxt/" title="Bitcoin XT on Docker Hub">bitcoinxt/bitcoinxt</a>
         </p>
         <p>
           This allows you to get a node up and running in seconds. All you need is a machine capable of running <a href="https://www.docker.com/" title="Docker - Build, Ship, and Run Any App, Anywhere">docker</a>.


### PR DESCRIPTION
The docker image by 5an1ty does not exist anymore on hub.docker.com. I forked the image and published it as `bitcoinxt/bitcoinxt`.

Also made APT/Docker more visible on the front page:
![skjermbilde 2017-08-31 kl 22 47 10](https://user-images.githubusercontent.com/92707/29944674-b1869efe-8e9e-11e7-8fb9-3b2a6e6f3ab0.png)
